### PR TITLE
Add filtering by badge on team page

### DIFF
--- a/app/js/client.js
+++ b/app/js/client.js
@@ -3,14 +3,16 @@
 
 import '../styles/style.scss';
 
-import './skillFilter';
-import './skillToggle';
-
 import mdcAutoInit from '@material/auto-init';
 import {MDCRipple} from '@material/ripple';
 import {MDCTabBar, MDCTabBarScroller} from '@material/tabs';
+import {initSkillActions} from "./skillToggle";
+import {initTabbing} from './skillFilter';
 
 mdcAutoInit.register('MDCTabBarScroller', MDCTabBarScroller);
 mdcAutoInit.register('MDCTabBar', MDCTabBar);
 mdcAutoInit.register('MDCRipple', MDCRipple);
 mdcAutoInit();
+
+initTabbing(); // This needs to happen after UI is initialized since we remove one of the tab-indicators here.
+initSkillActions();

--- a/app/js/skillFilter.js
+++ b/app/js/skillFilter.js
@@ -23,33 +23,40 @@ function displayCards(predicate) {
   });
 }
 
-function initTabbing() {
-  document.querySelectorAll(selectors.rankTab).forEach(function(tab) {
-    tab.addEventListener('click', function(e) {
-      displayCards(cardData => cardData.skillRank === e.target.dataset.rank);
-      const oldActive = document.querySelector('.rank-select__tab.mdc-tab--active');
-      if(oldActive) {
-        oldActive.classList.toggle('mdc-tab--active');
-      }
-      tab.classList.toggle('mdc-tab--active');
-    });
-  });
+export function initTabbing() {
+  if(document.querySelector(selectors.teamInfo)) {
+    document.querySelectorAll(selectors.rankTab).forEach(function(tab) {
+      tab.addEventListener('click', function(e) {
+        displayCards(cardData => cardData.skillRank === e.target.dataset.rank);
+        const oldActive = document.querySelector('.rank-select__tab.mdc-tab--active');
+        if(oldActive) {
+          oldActive.classList.toggle('mdc-tab--active');
+        }
+        tab.classList.toggle('mdc-tab--active');
 
-  document.querySelectorAll(selectors.badgeSelect).forEach(function(tab) {
-    tab.addEventListener('click', function(e) {
-      let elem = e.target;
-      while (elem && !elem.dataset.badge) {
-        elem = elem.parentNode;
-      }
-      displayCards(cardData => cardData.skillBadges.split(',').includes(elem.dataset.badge));
+        document.querySelector('.rank-select .tab-bar-indicator-marker').classList.add("mdc-tab-bar__indicator");
+        document.querySelector('.badge-select .tab-bar-indicator-marker').classList.remove("mdc-tab-bar__indicator");
+      });
     });
-  });
-  const activeRank = document.querySelector(selectors.rankTabs).dataset.activeRank;
-  displayCards(cardData => cardData.skillRank === activeRank);
-  window.location.hash = activeRank;
+
+    document.querySelectorAll(selectors.badgeSelect).forEach(function(tab) {
+      tab.addEventListener('click', function(e) {
+        let elem = e.target;
+        while (elem && !elem.dataset.badge) {
+          elem = elem.parentNode;
+        }
+        displayCards(cardData => cardData.skillBadges.split(',').includes(elem.dataset.badge));
+        document.querySelector('.rank-select .tab-bar-indicator-marker').classList.remove("mdc-tab-bar__indicator");
+        document.querySelector('.badge-select .tab-bar-indicator-marker').classList.add("mdc-tab-bar__indicator");
+      });
+    });
+
+    const activeRank = document.querySelector(selectors.rankTabs).dataset.activeRank;
+    displayCards(cardData => cardData.skillRank === activeRank);
+    window.location.hash = activeRank;
+
+    document.querySelector('.badge-select .tab-bar-indicator-marker').classList.remove("mdc-tab-bar__indicator");
+  }
 }
 
-if(document.querySelector(selectors.teamInfo)) {
-  initTabbing();
-}
 

--- a/app/js/skillFilter.js
+++ b/app/js/skillFilter.js
@@ -2,23 +2,23 @@
 'use strict';
 
 const selectors = {
+  badgeSelect: '.badge-select',
   skillCard: '.skill-list__item',
   rankTabs: '.rank-select',
   rankTab: '.rank-select__tab',
   teamInfo: '.team-info'
 };
 
-function displayCards(rank) {
+function displayCards(predicate) {
   document.querySelectorAll(selectors.skillCard).forEach(function(card) {
-    const { skillRank } = card.dataset;
-    if(rank === 'all') {
+    if(predicate === 'all') { // FIXME: dirty hack, is this even necessary?
       card.style.display = 'block';
       return;
     }
-    if(skillRank !== rank) {
-      card.style.display = 'none';
-    } else  {
+    if(predicate(card.dataset)) {
       card.style.display = 'block';
+    } else  {
+      card.style.display = 'none';
     }
   });
 }
@@ -26,7 +26,7 @@ function displayCards(rank) {
 function initTabbing() {
   document.querySelectorAll(selectors.rankTab).forEach(function(tab) {
     tab.addEventListener('click', function(e) {
-      displayCards(e.target.dataset.rank);
+      displayCards(cardData => cardData.skillRank === e.target.dataset.rank);
       const oldActive = document.querySelector('.rank-select__tab.mdc-tab--active');
       if(oldActive) {
         oldActive.classList.toggle('mdc-tab--active');
@@ -34,8 +34,18 @@ function initTabbing() {
       tab.classList.toggle('mdc-tab--active');
     });
   });
+
+  document.querySelectorAll(selectors.badgeSelect).forEach(function(tab) {
+    tab.addEventListener('click', function(e) {
+      let elem = e.target;
+      while (elem && !elem.dataset.badge) {
+        elem = elem.parentNode;
+      }
+      displayCards(cardData => cardData.skillBadges.split(',').includes(elem.dataset.badge));
+    });
+  });
   const activeRank = document.querySelector(selectors.rankTabs).dataset.activeRank;
-  displayCards(activeRank);
+  displayCards(cardData => cardData.skillRank === activeRank);
   window.location.hash = activeRank;
 }
 

--- a/app/js/skillToggle.js
+++ b/app/js/skillToggle.js
@@ -35,7 +35,7 @@ function toggleSkillState(id) {
   }
 }
 
-function initSkillActions() {
+export function initSkillActions() {
   const skills = document.querySelectorAll(selectors.skillItem);
   skills.forEach(function(skill) {
     skill.addEventListener('click', function(e) {
@@ -69,5 +69,3 @@ function initSkillActions() {
     });
   });
 }
-
-initSkillActions();

--- a/server/composer.js
+++ b/server/composer.js
@@ -75,12 +75,20 @@ async function getTeamRepresentation(name) {
     return withState;
   });
 
+  const allSkillsWithStateAndBadges = allSkillsWithState.map(skill => {
+    const withBadges = Object.assign({}, skill);
+    withBadges.badges = allBadges
+      .filter(badge => badge.requiredSkills.includes(skill.id))
+      .map(badge => badge.id);
+    return withBadges;
+  });
+
   const composed = {
     id: slug(teamInfo.name),
     name: teamInfo.name,
     securityChampion: teamInfo.champion,
     belt: teamInfo.belt,
-    skills: allSkillsWithState,
+    skills: allSkillsWithStateAndBadges,
     skillCount: teamInfo.skillCount,
     badges: teamBadges
   };

--- a/server/views/team.pug
+++ b/server/views/team.pug
@@ -18,20 +18,24 @@ block content
           a(href='mailto:' + team.securityChampion.email)
             strong= team.securityChampion.name
 
-        div(class='mdc-layout-grid__inner')
-          each badge in  team.badges
-            div(class='mdc-layout-grid__cell')
-              a(class="badge-select" href=`#badge-${badge.id}` data-badge=badge.id)
-                div(class='mdc-grid-tile__primary')
-                  div(class='mdc-grid-tile__primary-content')
-                    if badge.isComplete
-                      i(class='material-icons badge--achieved') done
-                    else
-                      i(class='material-icons badge--unachieved') error
-                div(class='mdc-grid-tile__secondary')
-                  span(class='mdc-grid-tile__title')= badge.title
+      div(data-mdc-auto-init='MDCTabBarScroller' class='mdc-tab-bar-scroller mdc-layout-grid__cell--span-12 belt-toolbar mdc-theme--dark')
+        div(class='mdc-tab-bar-scroller__indicator mdc-tab-bar-scroller__indicator--back')
+          a(class='mdc-tab-bar-scroller__indicator__inner material-icons' href='#' aria-label='scroll back button') navigate_before
+        div(class='mdc-tab-bar-scroller__scroll-frame')
+          nav(class='mdc-tab-bar mdc-tab-bar-scroller__scroll-frame__tabs badge-select')
+            each badge in  team.badges
+              a(class="mdc-tab mdc-tab--with-icon-and-text mdc-tab--active " href=`#badge-${badge.id}` data-badge=badge.id)
+                if badge.isComplete
+                  i(class='material-icons badge--achieved') done
+                else
+                  i(class='material-icons badge--unachieved') error
+                span(class="mdc-tab__icon-text")= badge.title
+            span(class='mdc-tab-bar__indicator tab-bar-indicator-marker')
+        div(class='mdc-tab-bar-scroller__indicator mdc-tab-bar-scroller__indicator--forward')
+          a(class='mdc-tab-bar-scroller__indicator__inner material-icons' href='#' aria-label='scroll forward button') navigate_next
 
-      div(data-mdc-auto-init='MDCTabBarScroller' class='mdc-tab-bar-scroller mdc-layout-grid__cell--span-12 belt-toolbar')
+
+      div(data-mdc-auto-init='MDCTabBarScroller' class='mdc-tab-bar-scroller mdc-layout-grid__cell--span-12 belt-toolbar mdc-theme--dark')
         div(class='mdc-tab-bar-scroller__indicator mdc-tab-bar-scroller__indicator--back')
           a(class='mdc-tab-bar-scroller__indicator__inner material-icons' href='#' aria-label='scroll back button') navigate_before
         div(class='mdc-tab-bar-scroller__scroll-frame')
@@ -39,7 +43,7 @@ block content
             each beltColor in beltKeys
               if beltColor !== 'white'
                 a(data-rank=beltColor class=`${beltColor}-belt ${nextBelt == beltColor ? 'mdc-tab--active' : ''} mdc-tab rank-select__tab` href=`#${beltColor}`)= beltNames[beltColor]
-            span(class='mdc-tab-bar__indicator')
+            span(class='mdc-tab-bar__indicator tab-bar-indicator-marker')
         div(class='mdc-tab-bar-scroller__indicator mdc-tab-bar-scroller__indicator--forward')
           a(class='mdc-tab-bar-scroller__indicator__inner material-icons' href='#' aria-label='scroll forward button') navigate_next
 

--- a/server/views/team.pug
+++ b/server/views/team.pug
@@ -12,7 +12,7 @@ block content
       section(class='center mdc-layout-grid__cell--span-12 team-info')
         h1(class='mdc-typography--display2')= 'Team ' + team.name
         h2(class='mdc-typography--display1')
-          strong Belt: 
+          strong Belt:
           strong(class=`team-info__belt ${team.belt}-belt-text`)= beltNames[team.belt]
         h3(class='mdc-typography--headline')= 'Security Champion: '
           a(href='mailto:' + team.securityChampion.email)
@@ -21,7 +21,7 @@ block content
         div(class='mdc-layout-grid__inner')
           each badge in  team.badges
             div(class='mdc-layout-grid__cell')
-              a(href="/badges")
+              a(class="badge-select" href=`#badge-${badge.id}` data-badge=badge.id)
                 div(class='mdc-grid-tile__primary')
                   div(class='mdc-grid-tile__primary-content')
                     if badge.isComplete
@@ -46,5 +46,5 @@ block content
   section(class='card-grid mdc-layout-grid')
     div(class='mdc-layout-grid__inner skill-list')
     each skill in team.skills
-      div(class='mdc-layout-grid__cell skill-list__item' data-skill-rank=skill.rank data-skill-id=skill.id)
+      div(class='mdc-layout-grid__cell skill-list__item' data-skill-badges=skill.badges.join(",") data-skill-rank=skill.rank data-skill-id=skill.id)
         include skill-item.pug

--- a/test/composer-test.js
+++ b/test/composer-test.js
@@ -30,7 +30,7 @@ describe('Composer', () => {
       assert.equal(result.belt, 'white');
       assert.equal(result.skillCount, 1);
       assert.deepEqual(result.skills, [
-        { title: 'My skill', id: 'my-skill', name: 'my-skill', rank: 'yellow', state: 'closed', links: [] }
+        { title: 'My skill', id: 'my-skill', name: 'my-skill', rank: 'yellow', state: 'closed', links: [], badges: ['my-badge'] }
       ]);
       assert.deepEqual(result.badges, [
         {


### PR DESCRIPTION
## Proposed Changes

Changes behaviour of the badge button on the team-page: Instead of switching to the badge overview, it filters the skill-cards on the team-page similar to the behavior when clicking on skills: 

![screenrecording](http://g.recordit.co/HCZOm4uBZ3.gif)

## Reasoning

As a user who wants to get a certain badge, it's currently hard to find out which skills are missing and what the details of the skill are. This change should simplify this by making the behaviour for badges similar to the behaviour for belts (i.e. a filtered card overview). 

## Still To Do

I'm not a frontend expert so the styling is still a bit broken, help would be highly appreciated ;)

* [x] Styling: Highlight active badge
* [x] Styling: Remove highlighting from skill buttons when filtering by badge