### PR TITLE
chore(*): typo fix for skill-items button

### DIFF
--- a/server/views/skill-item.pug
+++ b/server/views/skill-item.pug
@@ -12,4 +12,4 @@ div(class=`mdc-card skill-item skill-item__${skill.state}` data-team-name=team.n
     section(class='mdc-card__actions')
       each link in skill.links
         a(class='mdc-card__action' href=link.url)
-          button(data-mdc-auto-init='MDCRipple' class='mdc-button mdc-button--raised primary-billed-button')= link.title
+          button(data-mdc-auto-init='MDCRipple' class='mdc-button mdc-button--raised primary-filled-button')= link.title


### PR DESCRIPTION
Fixes #

Typo in button class.

## Additional Information (optional)

This also seems related to broken display of the buttons in Google Chrome (65.0.3325.181). Typo fix doesn't fix the issue though:

![image](https://user-images.githubusercontent.com/30344579/46536721-a05bc180-c8af-11e8-9c9c-6c1bc7ab2c54.png)

not sure if that is intentional and only firefox is supported?

Firefox displays the button text as expected.